### PR TITLE
Add pre-merge & post-release GH Actions workflows

### DIFF
--- a/.github/workflows/post-release.yaml
+++ b/.github/workflows/post-release.yaml
@@ -1,0 +1,28 @@
+name: Post release publish
+on:
+
+  release:
+    types: [published]
+env:
+  REGISTRY: ghcr.io
+  REPOSITORY_NAME: ${{ github.repository }}
+  DANA_ORG: dana-team
+
+jobs:
+  build-and-push-image:
+    name: Build and push image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Log in to the Container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push docker image
+        run: make docker-build docker-push IMG=${{ env.REGISTRY }}/${{ env.REPOSITORY_NAME }}:${GITHUB_REF##*/}

--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -1,0 +1,63 @@
+name: Pre Merge E2E test
+
+on:
+  pull_request:
+    branches:
+      - main
+    types: [opened, reopened, synchronize]
+
+jobs:
+  e2e-tests:
+    name: E2e-tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      IMAGE_REGISTRY: kind-registry:5000
+      KIND_VERSION: v0.18.0
+      K8S_VERSION: v1.26.3
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Go
+        uses: actions/setup-go@v4
+        with:
+          go-version-file: go.mod
+      - name: Configure insecure registry
+        run: |
+          #sudo cat /etc/docker/daemon.json
+          
+          # allow insecure registry but keep original config!
+          sudo bash -c "cat <<EOF >/etc/docker/daemon.json
+          {
+            \"exec-opts\": [\"native.cgroupdriver=cgroupfs\"],
+            \"cgroup-parent\": \"/actions_job\",
+            \"insecure-registries\" : [\"${IMAGE_REGISTRY}\"]
+          }
+          EOF"
+          
+          #sudo cat /etc/docker/daemon.json
+          sudo systemctl restart docker
+          
+          # same for podman
+          sudo bash -c "cat <<EOF >/etc/containers/registries.conf
+          [[registry]]
+          location=\"${IMAGE_REGISTRY}\"
+          insecure=true
+          EOF"
+          #sudo cat /etc/containers/registries.conf
+
+      - name: Start kind cluster
+        uses: container-tools/kind-action@v2
+        with:
+          version: ${{env.KIND_VERSION}}
+          config: ./hack/kind-config.yaml
+          node_image: kindest/node:${{env.K8S_VERSION}}
+          kubectl_version: ${{env.K8S_VERSION}}
+          registry: true
+
+      - name: Build nfspvc image
+        run: make docker-build docker-push IMG=${IMAGE_REGISTRY}/nfspvc-operator:test-${GITHUB_REF##*/}
+      - name: Deploy to cluster
+        run: make install deploy IMG=${IMAGE_REGISTRY}/nfspvc-operator:test-${GITHUB_REF##*/}
+      - name: E2e-test
+        run: make test-e2e


### PR DESCRIPTION
- Pre-merge workflow (pre-merge.yaml):
  - Run E2E tests on pull requests to the main branch
  - Set up Go, configure insecure registry, start a kind cluster, build and deploy NFSPVC image, and run E2E tests

- Post-release workflow (post-release.yaml):
  - Triggered on published releases
  - Build and push Docker image to ghcr.io/dana-team/nfspvc-operator with the release tag