### PR TITLE
Add kind-config.yaml for e2e tests

### DIFF
--- a/hack/kind-config.yaml
+++ b/hack/kind-config.yaml
@@ -1,0 +1,13 @@
+# four node (one control plane + three workers) cluster config for k8s e2e test in github workflow!
+# for the local registry config see https://kind.sigs.k8s.io/docs/user/local-registry/
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+  - role: control-plane
+  - role: worker
+  - role: worker
+  - role: worker
+containerdConfigPatches:
+  - |-
+    [plugins."io.containerd.grpc.v1.cri".registry.mirrors."kind-registry:5000"]
+      endpoint = ["http://kind-registry:5000"]

--- a/test/e2e_tests/e2e_test.go
+++ b/test/e2e_tests/e2e_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 const (
-	TimeoutNfsPvc          = 30 * time.Second
+	TimeoutNfsPvc          = 60 * time.Second
 	NfsPvcCreationInterval = 5 * time.Second
 )
 


### PR DESCRIPTION
Added a kind configuration file for setting up a four-node Kubernetes cluster suitable for e2e testing in GitHub workflows.