### PR TITLE
updated TimeoutNfsPvc

### DIFF
--- a/test/e2e_tests/e2e_test.go
+++ b/test/e2e_tests/e2e_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 const (
-	TimeoutNfsPvc          = 30 * time.Second
+	TimeoutNfsPvc          = 60 * time.Second
 	NfsPvcCreationInterval = 5 * time.Second
 )
 


### PR DESCRIPTION
Increased the timeout value for NFS PVC from 30 to 60 seconds.