### PR TITLE
fix: add patch role to allow for helm upgrades

### DIFF
--- a/config/rbac/nfspvc_aggregate_to_admin.yaml
+++ b/config/rbac/nfspvc_aggregate_to_admin.yaml
@@ -13,4 +13,4 @@ metadata:
 rules:
 - apiGroups: ["nfspvc.dana.io"]
   resources: ["nfspvcs"]
-  verbs: ["get", "list", "watch", "create", "delete", "update", "list"]	
+  verbs: ["get", "list", "watch", "create", "delete", "update", "list", "patch"]


### PR DESCRIPTION
With this pr, the `patch` verb has been added to the `ClusterRole` that is aggregated to `admin` .
This fixes an issue where and account with this role bound was not allowed to perform  a `helm upgrade`.